### PR TITLE
Issueの修正

### DIFF
--- a/Assets/Dev/Dev_Branchs/stage/Master_Ingame_Stage(Copy).unity
+++ b/Assets/Dev/Dev_Branchs/stage/Master_Ingame_Stage(Copy).unity
@@ -395,6 +395,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Wall
       objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -462,6 +467,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Wall (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
@@ -531,6 +541,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Wall (5)
       objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -598,6 +613,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Wall (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
@@ -667,6 +687,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Wall (2)
       objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -722,12 +747,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 587a7ac46c6ef654292713c44b49d468, type: 3}
---- !u!4 &1299293379 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2782304487744603710, guid: 77fd2a5407b56e54d8e660f62bd21e54,
-    type: 3}
-  m_PrefabInstance: {fileID: 3352846947418109805}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1343729843
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -740,6 +759,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Wall (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
@@ -817,7 +841,7 @@ PrefabInstance:
     - target: {fileID: 2710484828236544335, guid: 022a7869d00083b4586bf6fdf5f0ae30,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -12.5
+      value: 7.500002
       objectReference: {fileID: 0}
     - target: {fileID: 2710484828236544335, guid: 022a7869d00083b4586bf6fdf5f0ae30,
         type: 3}
@@ -862,7 +886,7 @@ PrefabInstance:
     - target: {fileID: 9031967255871615067, guid: 022a7869d00083b4586bf6fdf5f0ae30,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -881,6 +905,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Wall (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
         type: 3}
@@ -968,7 +997,7 @@ PrefabInstance:
     - target: {fileID: 3698190226752413269, guid: 9c96090de5b97f94d91628fd67edcc8a,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 25
+      value: 27.3
       objectReference: {fileID: 0}
     - target: {fileID: 3698190226752413269, guid: 9c96090de5b97f94d91628fd67edcc8a,
         type: 3}
@@ -978,7 +1007,7 @@ PrefabInstance:
     - target: {fileID: 3698190226752413269, guid: 9c96090de5b97f94d91628fd67edcc8a,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -36.56
+      value: -15.62
       objectReference: {fileID: 0}
     - target: {fileID: 3698190226752413269, guid: 9c96090de5b97f94d91628fd67edcc8a,
         type: 3}
@@ -1083,27 +1112,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: StageManager
       objectReference: {fileID: 0}
-    - target: {fileID: 3538332611585799522, guid: 77fd2a5407b56e54d8e660f62bd21e54,
-        type: 3}
-      propertyPath: _obstaclePrefabList.Array.data[0].VisualGuide
-      value: 
-      objectReference: {fileID: 3365111522871868215}
-    - target: {fileID: 5503873840338744912, guid: 77fd2a5407b56e54d8e660f62bd21e54,
+    - target: {fileID: 7212133291848024612, guid: 77fd2a5407b56e54d8e660f62bd21e54,
         type: 3}
       propertyPath: _canvas
       value: 
       objectReference: {fileID: 518106097}
-    - target: {fileID: 5503873840338744912, guid: 77fd2a5407b56e54d8e660f62bd21e54,
-        type: 3}
-      propertyPath: _healthBar
-      value: 
-      objectReference: {fileID: 6218801146707754616, guid: a3d6ce18078983a49a949e9f607d794c,
-        type: 3}
-    - target: {fileID: 5503873840338744912, guid: 77fd2a5407b56e54d8e660f62bd21e54,
-        type: 3}
-      propertyPath: _targetPos
-      value: 
-      objectReference: {fileID: 1299293379}
     - target: {fileID: 8491387007585437238, guid: 77fd2a5407b56e54d8e660f62bd21e54,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1233,7 +1246,7 @@ Transform:
   m_GameObject: {fileID: 3365111522871868215}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 27.5, y: 0, z: -32.5}
+  m_LocalPosition: {x: -50, y: 0, z: -32.5}
   m_LocalScale: {x: 5, y: 5, z: 5}
   m_ConstrainProportionsScale: 1
   m_Children: []

--- a/Assets/Dev/Dev_Branchs/stage/StageManager.cs
+++ b/Assets/Dev/Dev_Branchs/stage/StageManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DCFrameWork.Enemy;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,19 +8,20 @@ using UnityEngine;
 
 public class StageManager : MonoBehaviour
 {
-    [SerializeField] Transform _spawnPos;
-    [SerializeField] Transform _targetPos;
     [SerializeField] GameObject _floorPrefab;
     [SerializeField] float _gridSize = 5f;
     [SerializeField] List<ObstaclePrefabs> _obstaclePrefabList;
+    [SerializeField] GameObject _defaultVisualGuide;
     //[SerializeField] GameObject _clickPointPrefab;//Debug;
     [Serializable]
     public struct ObstaclePrefabs
     {
         public string Name;
         public GameObject PutObstaclePrefab;
-        public GameObject VisualGuide;
+        [Tooltip("特注の視覚サポートオブジェクトがあればいれてください")]public GameObject VisualGuide;
     }
+    Transform _spawnPos;
+    Transform _targetPos;
     GameObject _setPrefab;
     GameObject _tentativePrefab;
     GameObject _wallsParent;
@@ -37,6 +39,9 @@ public class StageManager : MonoBehaviour
     //計算に関するコメントアウトのメモが噓をついている可能性があります。鵜吞みにしないように。発見したら教えてください。
     void Start()
     {
+        var enemyGenerator = GetComponentInChildren<EnemyGenerator>();
+        _spawnPos = enemyGenerator.SpawnPos;
+        _targetPos = enemyGenerator.TargetPos;
         _wallsParent = new GameObject();
         _wallsParent.transform.SetParent(transform);
         _wallsParent.name = "Obstacle Parent";
@@ -53,7 +58,14 @@ public class StageManager : MonoBehaviour
         _startZ = (int)((_targetPos.position.z - _floorCenter.z + _floorPrefab.transform.localScale.z / 2 - _gridSize / 2) / _gridSize);
         //デフォルトで配置するオブジェクトをセットしてる。後から消すかも？
         _setPrefab = _obstaclePrefabList[0].PutObstaclePrefab;
-        _tentativePrefab = _obstaclePrefabList[0].VisualGuide;
+        if (_obstaclePrefabList[0].VisualGuide == null)
+        {
+            _tentativePrefab = _defaultVisualGuide;
+        }
+        else
+        {
+            _tentativePrefab = _obstaclePrefabList[0].VisualGuide;
+        }
         LoadStage();
         //ステージのグリッド座標に壁があるかしらべて2次元配列に格納
         void LoadStage()

--- a/Assets/Dev/Dev_Branchs/stage/StageManager.prefab
+++ b/Assets/Dev/Dev_Branchs/stage/StageManager.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &1650601316748778162
+--- !u!1 &464214968419229631
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,29 +8,84 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4403459864087168257}
+  - component: {fileID: 9083700419108691442}
+  - component: {fileID: 6394195920686785024}
+  - component: {fileID: 6632971086259367857}
   m_Layer: 0
-  m_Name: ObstacleObjects
+  m_Name: DefaultVisualGuide
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4403459864087168257
+--- !u!4 &9083700419108691442
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1650601316748778162}
+  m_GameObject: {fileID: 464214968419229631}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 51.74877, y: 17.463524, z: -19.72748}
+  m_LocalScale: {x: 5, y: 5, z: 5}
+  m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 8491387007585437238}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6394195920686785024
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464214968419229631}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6632971086259367857
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464214968419229631}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: c9f871b5c0c9b6c48bd582f2b1a59cb0, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!1 &2621820399409381263
 GameObject:
   m_ObjectHideFlags: 0
@@ -203,10 +258,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
+  - {fileID: 9083700419108691442}
   - {fileID: 5126188808095790956}
   - {fileID: 8272773311129582984}
-  - {fileID: 4403459864087168257}
-  - {fileID: 5638435478133149944}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &3538332611585799522
@@ -224,15 +278,13 @@ MonoBehaviour:
   _spawnPos: {fileID: 7703117587782075800}
   _targetPos: {fileID: 2782304487744603710}
   _floorPrefab: {fileID: 2621820399409381263}
-  _floorCenter: {x: 25, y: 0, z: -25}
   _gridSize: 5
   _obstaclePrefabList:
   - Name: 
     PutObstaclePrefab: {fileID: 9031967255871615067, guid: 022a7869d00083b4586bf6fdf5f0ae30,
       type: 3}
-    VisualGuide: {fileID: 835390379413496201}
-  _navMeshSurface: {fileID: 8015407683335857790}
-  _wallsParent: {fileID: 1650601316748778162}
+    VisualGuide: {fileID: 0}
+  _defaultVisualGuide: {fileID: 464214968419229631}
 --- !u!1 &5865097026064514226
 GameObject:
   m_ObjectHideFlags: 0
@@ -304,7 +356,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8272773311129582984}
-  - component: {fileID: 5503873840338744912}
+  - component: {fileID: 7212133291848024612}
   m_Layer: 0
   m_Name: EnemyGenerator
   m_TagString: Untagged
@@ -329,7 +381,7 @@ Transform:
   - {fileID: 2782304487744603710}
   m_Father: {fileID: 8491387007585437238}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &5503873840338744912
+--- !u!114 &7212133291848024612
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -338,12 +390,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 8835070901223828311}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 700c9865b3aa14a4485d5862cd126839, type: 3}
+  m_Script: {fileID: 11500000, guid: 8a60d3713b0c1ad46a7109decd8d3e27, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   _objects:
-  - {fileID: 7990310466857601233, guid: 837ec1f55b14f894e8397ccb545f2850, type: 3}
-  - {fileID: 7990310466857601233, guid: 837ec1f55b14f894e8397ccb545f2850, type: 3}
+  - EnemyPrefab: {fileID: 7990310466857601233, guid: 837ec1f55b14f894e8397ccb545f2850,
+      type: 3}
+    SpawnChance: 50
   _spawnPos: {fileID: 7703117587782075800}
   _targetPos: {fileID: 2782304487744603710}
   _canvas: {fileID: 0}
@@ -352,88 +405,3 @@ MonoBehaviour:
   _defaultValue: 1
   _maxValue: 100
   _spawnInterval: 3
---- !u!1001 &4459538739300219831
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 8491387007585437238}
-    m_Modifications:
-    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_Name
-      value: Wall
-      objectReference: {fileID: 0}
-    - target: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -48
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 587a7ac46c6ef654292713c44b49d468, type: 3}
---- !u!1 &835390379413496201 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3923921449293535806, guid: 587a7ac46c6ef654292713c44b49d468,
-    type: 3}
-  m_PrefabInstance: {fileID: 4459538739300219831}
-  m_PrefabAsset: {fileID: 0}
---- !u!4 &5638435478133149944 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8348769818262055759, guid: 587a7ac46c6ef654292713c44b49d468,
-    type: 3}
-  m_PrefabInstance: {fileID: 4459538739300219831}
-  m_PrefabAsset: {fileID: 0}

--- a/Assets/Master/Scenes/Master_Scene/IngameScene/Master_Ingame_Stage1.unity
+++ b/Assets/Master/Scenes/Master_Scene/IngameScene/Master_Ingame_Stage1.unity
@@ -279,6 +279,11 @@ PrefabInstance:
       propertyPath: _canvas
       value: 
       objectReference: {fileID: 518106097}
+    - target: {fileID: 7212133291848024612, guid: 77fd2a5407b56e54d8e660f62bd21e54,
+        type: 3}
+      propertyPath: _canvas
+      value: 
+      objectReference: {fileID: 518106097}
     - target: {fileID: 8015407683335857790, guid: 77fd2a5407b56e54d8e660f62bd21e54,
         type: 3}
       propertyPath: m_NavMeshData

--- a/Assets/Master/Script/InGame/Enemy/EnemyGenerator.cs
+++ b/Assets/Master/Script/InGame/Enemy/EnemyGenerator.cs
@@ -17,9 +17,13 @@ namespace DCFrameWork.Enemy
 
         [SerializeField]
         private Transform _spawnPos;
+        
+        public Transform SpawnPos {  get { return _spawnPos; } set { _spawnPos = value; } }
 
         [SerializeField]
         private Transform _targetPos;
+
+        public Transform TargetPos { get { return _targetPos; } set { _targetPos = value; } }
 
         [SerializeField]
         private Canvas _canvas;

--- a/Assets/Master/Script/InGame/Enemy/EnemyGenerator.cs
+++ b/Assets/Master/Script/InGame/Enemy/EnemyGenerator.cs
@@ -18,12 +18,12 @@ namespace DCFrameWork.Enemy
         [SerializeField]
         private Transform _spawnPos;
         
-        public Transform SpawnPos {  get { return _spawnPos; } set { _spawnPos = value; } }
+        public Transform SpawnPos {  get { return _spawnPos; } }
 
         [SerializeField]
         private Transform _targetPos;
 
-        public Transform TargetPos { get { return _targetPos; } set { _targetPos = value; } }
+        public Transform TargetPos { get { return _targetPos; } }
 
         [SerializeField]
         private Canvas _canvas;


### PR DESCRIPTION
StageManagerの_startPos、_targetPosがEnemyGeneratorのTransformフィールドのプロパティを参照する形に。
タレットを設置する際のプレビューのブロック（白いボックス）が障害物の判定を持っており、設置していないにも関わらず経路を変えてしまう問題はNavMeshObstacleのついていないオブジェクトを用意して対応。