### PR TITLE
BuildNavMeshをstaticなオブジェクトに対して行うとエラーが出るらしいので処理を消しました。

### DIFF
--- a/Assets/Dev/Dev_Branchs/stage/StageManager.cs
+++ b/Assets/Dev/Dev_Branchs/stage/StageManager.cs
@@ -48,7 +48,6 @@ public class StageManager : MonoBehaviour
         _wallsParent = new GameObject();
         _wallsParent.transform.SetParent(transform);
         _wallsParent.name = "Obstacle Parent";
-        GetComponentInChildren<NavMeshSurface>().BuildNavMesh();
         _mainCamera = Camera.main;
         //_floorCenter = new Vector3(_floorPrefab.transform.position.x + _floorPrefab.transform.localScale.x / 2, _floorPrefab.transform.position.y, _floorPrefab.transform.position.z - _floorPrefab.transform.localScale.z / 2);
         _floorCenter = transform.position;


### PR DESCRIPTION
メッシュが Static としてマークされている場合、そのメッシュは実行時に変更できないことがあるらしくNavMeshBuilder.BuildNavMeshData はメッシュデータを操作するため、これにアクセスできない場合にエラーが発生するそうです。GroundはStaticなので、NavMeshは各ステージのシーン上で直接ベイクする必要があります。