### PR TITLE
[fix]お宝の上にタレット設置できるバグの修正

### DIFF
--- a/Assets/Master/Script/InGame/Stage/StageManager.cs
+++ b/Assets/Master/Script/InGame/Stage/StageManager.cs
@@ -113,7 +113,7 @@ public class StageManager : MonoBehaviour
     }
     void Update()
     {
-        if(Input.GetMouseButtonDown(1))
+        if (Input.GetMouseButtonDown(1))
         {
             SetTurretCancel();
         }
@@ -157,7 +157,7 @@ public class StageManager : MonoBehaviour
             {
                 _tentativePrefab.SetActive(true);
                 //置けるかどうかの判定
-                if (CheckConnected(_currentPosition) && !_spawnPos.Contains(_currentPosition) && _currentPosition != _targetPos)
+                if (CheckConnected(_currentPosition) && !_spawnPos.Contains(_currentPosition) && _currentPosition != _targetPos && _currentPosition != _targetPos + new Vector3(0, _gridSize, 0))
                 {
                     _tentativePrefab.GetComponent<MeshRenderer>().material.color = Color.white;
                     _canSet = true;


### PR DESCRIPTION
バグの原因
・タレットを置けるかどうかにx座標とz座標しか考慮されていなかった。
お宝が(0,0,0)、タレットを置く場所(0,0,0)だったら(まったく同じ座標)置けないように設計されていたが、タレットを置く場所が(0,5,0)だと置けてしまった